### PR TITLE
Fix the error when the select value is equal to undefined.

### DIFF
--- a/src/components/slotSetting/SlotSetting.tsx
+++ b/src/components/slotSetting/SlotSetting.tsx
@@ -137,7 +137,7 @@ const SelectsTable: FC<SelectTableProps> = ( props: SelectTableProps ) => {
 				<Grid item xs key={reelIndex}>
 					<FormControl style={{ width: '100%' }}>
 						<Select
-							value={reelIndexes[ reelIndex ][ symbolIndex ]}
+							value={reelIndexes[ reelIndex ][ symbolIndex ] ? reelIndexes[ reelIndex ][ symbolIndex ] : 'undefined'}
 							onChange={handleSelectChange( { x: reelIndex, y: symbolIndex } )}
 						>
 							{options}


### PR DESCRIPTION
Fix:
Material-UI: A component is changing the controlled value state of Select to be uncontrolled.